### PR TITLE
Add a field that prints the root directory of the Cabal package

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Currently supported cabal fields are:
 
 There are further some special fields:
 * `package_db`
+* `root_dir`
 * `autogen_hs_source_dirs`
 * `autogen_include_dirs`
 * `autogen_includes`

--- a/cabal-cargs.cabal
+++ b/cabal-cargs.cabal
@@ -55,6 +55,7 @@ library
         cmdargs >=0.10.5 && <0.11,
         lens >=4.0.1 && <4.17,
         directory >=1.0 && <1.4,
+        filepath  >=1.0 && <1.5,
         transformers >=0.3.0.0 && <0.6,
         text >=1.1.0.1 && <1.3,
         system-filepath >=0.4.9 && <0.5,

--- a/lib/CabalCargs/BuildInfo.hs
+++ b/lib/CabalCargs/BuildInfo.hs
@@ -28,6 +28,7 @@ field F.Include_Dirs           = CL.includeDirsL
 field F.Includes               = CL.includesL
 field F.Build_Depends          = nopLens
 field F.Package_Db             = nopLens
+field F.Root_Dir               = nopLens
 field F.Autogen_Hs_Source_Dirs = nopLens
 field F.Autogen_Include_Dirs   = nopLens
 field F.Autogen_Includes       = nopLens

--- a/lib/CabalCargs/Fields.hs
+++ b/lib/CabalCargs/Fields.hs
@@ -29,6 +29,7 @@ data Field = Hs_Source_Dirs
            | Build_Depends
 
            | Package_Db             -- ^ the package database of a cabal sandbox
+           | Root_Dir               -- ^ the root directory of the cabal package
            | Autogen_Hs_Source_Dirs -- ^ dirs of automatically generated haskell source files by cabal (e.g. Paths_*)
            | Autogen_Include_Dirs   -- ^ dirs of automatically generated include files by cabal
            | Autogen_Includes       -- ^ automatically generated include files by cabal (e.g. cabal_macros.h)

--- a/lib/CabalCargs/Format.hs
+++ b/lib/CabalCargs/Format.hs
@@ -60,6 +60,7 @@ format Pure cargs = concat [ hsSourceDirs cargs
                            , includes cargs
                            , buildDepends cargs
                            , maybeToList $ packageDB cargs
+                           , maybeToList $ rootDir cargs
                            , autogenHsSourceDirs cargs
                            , autogenIncludeDirs cargs
                            , autogenIncludes cargs


### PR DESCRIPTION
See issue #5.